### PR TITLE
Fix common/cut symbols

### DIFF
--- a/xmlFiles/01b-Pitches-Intervals.xml
+++ b/xmlFiles/01b-Pitches-Intervals.xml
@@ -23,7 +23,7 @@
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
-        <time symbol="common">
+        <time>
           <beats>2</beats>
           <beat-type>4</beat-type>
         </time>

--- a/xmlFiles/11a-TimeSignatures.xml
+++ b/xmlFiles/11a-TimeSignatures.xml
@@ -5,7 +5,7 @@
   <identification>
     <miscellaneous>
       <miscellaneous-field name="description">Various time signatures: 2/2 
-            (alla breve), 4/4 (C), 2/2, 3/2, 2/4, 3/4, 4/4, 5/4, 3/8, 6/8, 
+            (alla breve, symbol="cut"), 4/4 (C, symbol="common"), 2/2, 3/2, 2/4, 3/4, 4/4, 5/4, 3/8, 6/8,
             12/8</miscellaneous-field>
     </miscellaneous>
   </identification>

--- a/xmlFiles/11f-TimeSignatures-SymbolMeaning.xml
+++ b/xmlFiles/11f-TimeSignatures-SymbolMeaning.xml
@@ -24,6 +24,7 @@
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
+        <!-- known incorrect usage. This is being tested -->
         <time symbol="cut">
           <beats>3</beats>
           <beat-type>8</beat-type>
@@ -47,6 +48,7 @@
     <!--=========================================================-->
     <measure number="2">
       <attributes>
+        <!-- known incorrect usage. This is being tested -->
         <time symbol="single-number">
           <beats>3+2</beats>
           <beat-type>8</beat-type>
@@ -74,6 +76,7 @@
     <!--=========================================================-->
     <measure number="3">
       <attributes>
+        <!-- known incorrect usage. This is being tested -->
         <time symbol="single-number">
           <beats>1</beats>
           <beat-type>8</beat-type>

--- a/xmlFiles/22d-Parenthesized-Noteheads.xml
+++ b/xmlFiles/22d-Parenthesized-Noteheads.xml
@@ -24,7 +24,7 @@
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
-        <time symbol="common">
+        <time>
           <beats>6</beats>
           <beat-type>4</beat-type>
         </time>

--- a/xmlFiles/23b-Tuplets-Styles.xml
+++ b/xmlFiles/23b-Tuplets-Styles.xml
@@ -23,7 +23,7 @@
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
-        <time symbol="common">
+        <time>
           <beats>5</beats>
           <beat-type>4</beat-type>
         </time>

--- a/xmlFiles/33e-Spanners-OctaveShifts-InvalidSize.xml
+++ b/xmlFiles/33e-Spanners-OctaveShifts-InvalidSize.xml
@@ -22,7 +22,7 @@
           <fifths>0</fifths>
           <mode>major</mode>
         </key>
-        <time symbol="common">
+        <time>
           <beats>3</beats>
           <beat-type>4</beat-type>
         </time>


### PR DESCRIPTION
PR #8 accidentally reintroduced a bug from Lilypond where a 2/4 measure was marked with symbol="common" -- I looked through the rest of the repo and found a few more cases like this.  Fixing them.  Marking the one case that shouldn ot be changed (though I think that this should go into a 95+ section instead).